### PR TITLE
Issue 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ PrivacyFlash Pro (1.0.2) was tested to run on macOS Catalina (10.15.5) and the B
 
 After successfully installing and running from source, run `python3 package.py` within the `privacyflash-pro/policygenerator` directory. A zipped file containg a MacOS distributable app will be generated in the `privacyflash-pro/policygenerator/dist` directory.
 
-**Note**: If packaging for release, remember to update the version number in `privacyflash-pro/policygenerator/interface/index.html` and `privacyflash-pro/policygenerator/package.py`.
+**Note**: If packaging for public distribution, remember to update the version number in `privacyflash-pro/policygenerator/interface/index.html` and `privacyflash-pro/policygenerator/package.py`.
+
+If you experience errors packaging or running the packaged app, try updating the dependency `pyinstaller` by running `pip3 install pyinstaller -U` and then run the packaging script.
 
 ## Demo Video
 

--- a/policygenerator/app.py
+++ b/policygenerator/app.py
@@ -21,7 +21,7 @@ from pathlib import Path
 isPackaged = getattr(sys, 'frozen', False)
 directory = str(Path.home())
 path = os.path.join(str(Path.home()), 'Library/Application Support/PrivacyFlash Pro') 
-database = os.path.join(path, 'shelf.db')
+database = os.path.join(path, 'shelf')
 showBootLogo = True
 
 try:
@@ -93,19 +93,31 @@ class Api():
 
     def updateDisclaimer(self):
         try:
-            db = shelve.open(database)
+            try:
+                db = shelve.open(database)
+            except Exception as e:
+                path = database + '.db' 
+                if os.path.exists(path):
+                    os.remove(path)
+                db = shelve.open(database)
             try:
                 db['disclaimer'] = True
             finally:
                 db.close()
             db = shelve.open(database)
             db.close()
-        except:
+        except Exception as e:
             print('Error: Unable to save user choice')
 
     def readDisclaimer(self):
         try:
-            db = shelve.open(database)
+            try:
+                db = shelve.open(database)
+            except Exception as e:
+                path = database + '.db' 
+                if os.path.exists(path):
+                    os.remove(path)
+                db = shelve.open(database)
             try:
                 if 'disclaimer' in db:
                     value = db['disclaimer']
@@ -115,7 +127,7 @@ class Api():
             finally:
                 db.close()
             return value
-        except:
+        except Exception as e:
             print('Error: Unable to access database')
             return False
     

--- a/policygenerator/requirements.txt
+++ b/policygenerator/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==5.1
 six==1.11.0
 pywebview==3.4
-pyinstaller==4.1
+pyinstaller


### PR DESCRIPTION
- I got some errors packaging the app. After updating pyinstaller, I was able to package the app. I updated the packaging instructions to account for this. At this time, I'm using `Python v3.9.1` and `pyinstaller v4.2`

- I also got an error trying to access our local storage. I updating the way we access our local database for reading and saving whether a user has agreed to the disclaimer. For reference, this is where we store user preferences - `~/Path/To/User/Library/Application Support/PrivacyFlash Pro/shelf.db` (The directory is usually hidden)